### PR TITLE
fix type definition of Errors

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,18 +2,18 @@ declare module "moleculer-web" {
     import { Errors, ServiceSchema } from "moleculer";
     class InvalidRequestBodyError extends Errors.MoleculerError { constructor(body: any, error: any) }
     class InvalidResponseTypeError extends Errors.MoleculerError { constructor(dataType: string) }
-    class UnAuthorizedError extends Errors.MoleculerError { constructor(type: string, data: any) }
+    class UnAuthorizedError extends Errors.MoleculerError { constructor(type: string|null|undefined, data: any) }
     class ForbiddenError extends Errors.MoleculerError { constructor(type: string, data: any) }
     class BadRequestError extends Errors.MoleculerError { constructor(type: string, data: any) }
     class RateLimitExceeded extends Errors.MoleculerClientError { constructor(type: string, data: any) }
 
     interface ApiGatewayErrors {
-        InvalidRequestBodyError: InvalidRequestBodyError;
-        InvalidResponseTypeError: InvalidResponseTypeError;
-        UnAuthorizedError: UnAuthorizedError;
-        ForbiddenError: ForbiddenError;
-        BadRequestError: BadRequestError;
-        RateLimitExceeded: RateLimitExceeded;
+        InvalidRequestBodyError: typeof InvalidRequestBodyError;
+        InvalidResponseTypeError: typeof InvalidResponseTypeError;
+        UnAuthorizedError: typeof UnAuthorizedError;
+        ForbiddenError: typeof ForbiddenError;
+        BadRequestError: typeof BadRequestError;
+        RateLimitExceeded: typeof RateLimitExceeded;
 
         ERR_NO_TOKEN: "ERR_NO_TOKEN";
         ERR_INVALID_TOKEN: "ERR_INVALID_TOKEN";


### PR DESCRIPTION
This fixes the TS definition to make it possible to do:

    throw new ApiGatewayService.Errors.UnAuthorizedError(...);

as seems to be the intent going by the JS implementation.

The previous TS definition meant that ApiGatewayService.Errors.UnAuthorizedError etc. were instances of those error types, not the constructor functions for those types.