### PR TITLE
Support nested objects in query params

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3100,6 +3100,7 @@
       "dev": true,
       "optional": true,
       "requires": {
+        "nan": "2.10.0",
         "node-pre-gyp": "0.6.39"
       },
       "dependencies": {
@@ -6682,6 +6683,13 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
+    "nan": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+      "dev": true,
+      "optional": true
+    },
     "nanomatch": {
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
@@ -8198,8 +8206,7 @@
     "qs": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
-      "dev": true
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
     },
     "querystring": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "lodash": "4.17.5",
     "nanomatch": "1.2.9",
     "path-to-regexp": "1.7.0",
+    "qs": "6.5.1",
     "serve-static": "1.13.2"
   },
   "engines": {

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@
 
 const http 						= require("http");
 const https 					= require("https");
-const queryString 				= require("querystring");
+const queryString 				= require("qs");
 const deprecate 				= require("depd")("moleculer-web");
 
 const _ 						= require("lodash");

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -789,6 +789,32 @@ describe("Test aliases", () => {
 			});
 	});
 
+	it("GET opt-test with array params", () => {
+		return request(server)
+			.get("/api/opt-test")
+			.query("a=1&a=2")
+			.expect(200)
+			.expect("Content-Type", "application/json; charset=utf-8")
+			.then(res => {
+				expect(res.body.params).toEqual({
+					a: ["1", "2"],
+				});
+			});
+	});
+
+	it("GET opt-test with nested params", () => {
+		return request(server)
+			.get("/api/opt-test")
+			.query("foo[bar]=a&foo[bar]=b&foo[baz]=c")
+			.expect(200)
+			.expect("Content-Type", "application/json; charset=utf-8")
+			.then(res => {
+				expect(res.body.params).toEqual({
+					foo: { bar: ["a", "b"], baz: "c" }
+				});
+			});
+	});
+
 	it("GET opt-test/:name? without name", () => {
 		return request(server)
 			.get("/api/opt-test")


### PR DESCRIPTION
While trying to expose a `moleculer-db` service through the API gateway I noticed there is no way to pass the `query` param to the services `list` action ([doc](https://github.com/moleculerjs/moleculer-db/tree/master/packages/moleculer-db#parameters-2)). The service expects the `query` param to be of type `object` but nested objects are not supported by node's `querystring` module (see https://github.com/nodejs/node-v0.x-archive/issues/1665).

This PR replaces `querystring` with [`qs`](https://github.com/ljharb/qs), which supports nested objects.

**Example Request:**
`GET /users/list?query[name]=Peter` 

**Before** (using [`querystring`](https://nodejs.org/api/querystring.html) module): 
`params: { "query[name]": "Peter" }`

**After** (using [`qs`](https://github.com/ljharb/qs) module): 
`params: { "query": { "name": "Peter" }}`

What do you think?