### PR TITLE
Do not log 4XX error responses if configured

### DIFF
--- a/examples/full/index.js
+++ b/examples/full/index.js
@@ -281,7 +281,10 @@ broker.createService({
 			res.setHeader("Content-Type", "text/plain");
 			res.writeHead(err.code || 500);
 			res.end("Global error: " + err.message);
-		}
+		},
+
+		// Do not log client side errors (does not log an error respons when the error.code is 400<=X<500)
+		log4XXResponses: false,
 
 	},
 

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ const isReadableStream			= require("isstream").isReadable;
 const pathToRegexp 				= require("path-to-regexp");
 
 const { MoleculerError, MoleculerServerError, ServiceNotFoundError } = require("moleculer").Errors;
-const { BadRequestError, NotFoundError, ForbiddenError, RateLimitExceeded, ERR_UNABLE_DECODE_PARAM, ERR_ORIGIN_NOT_FOUND, ERR_ORIGIN_NOT_ALLOWED } = require("./errors");
+const { BadRequestError, NotFoundError, ForbiddenError, RateLimitExceeded, ERR_UNABLE_DECODE_PARAM, ERR_ORIGIN_NOT_ALLOWED } = require("./errors");
 
 const MemoryStore				= require("./memory-store");
 
@@ -201,7 +201,7 @@ module.exports = {
 				.catch(err => {
 					// only log client side errors if configured to do so
 					if (this.settings.log4XXResponses || err && !_.inRange(err.code, 400, 500)) {
-            this.logger.error("   Request error!", err.name, ":", err.message, "\n", err.stack, "\nData:", err.data);
+						this.logger.error("   Request error!", err.name, ":", err.message, "\n", err.stack, "\nData:", err.data);
 					}
 					this.sendError(req, res, err);
 				});

--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,10 @@ module.exports = {
 		logRequestParams: "debug",
 
 		// Log the response data (default to disable)
-		logResponseData: null
+		logResponseData: null,
+
+		// If set to false, error responses with a status code indicating a client error will not be logged
+		log4XXResponses: true
 	},
 
 	/**
@@ -196,7 +199,10 @@ module.exports = {
 					}
 				})
 				.catch(err => {
-					this.logger.error("   Request error!", err.name, ":", err.message, "\n", err.stack, "\nData:", err.data);
+					// only log client side errors if configured to do so
+					if (this.settings.log4XXResponses || err && !_.inRange(err.code, 400, 500)) {
+            this.logger.error("   Request error!", err.name, ":", err.message, "\n", err.stack, "\nData:", err.data);
+					}
 					this.sendError(req, res, err);
 				});
 		},

--- a/src/index.js
+++ b/src/index.js
@@ -199,8 +199,8 @@ module.exports = {
 					}
 				})
 				.catch(err => {
-					// only log client side errors if configured to do so
-					if (this.settings.log4XXResponses || err && !_.inRange(err.code, 400, 500)) {
+					// don't log client side errors only it's configured
+					if (this.settings.log4XXResponses || (err && !_.inRange(err.code, 400, 500))) {
 						this.logger.error("   Request error!", err.name, ":", err.message, "\n", err.stack, "\nData:", err.data);
 					}
 					this.sendError(req, res, err);

--- a/test/unit/service/httpHandler.spec.js
+++ b/test/unit/service/httpHandler.spec.js
@@ -1,0 +1,239 @@
+"use strict";
+
+const HttpHandler = () => require("../../../src/index").methods.httpHandler;
+const MockLogger = () => Object.assign({
+	info: jest.fn(),
+	error: jest.fn(),
+	warning: jest.fn(),
+	debug: jest.fn(),
+	trace: jest.fn(),
+});
+const MockContext = () => Object.assign({
+	actions: {
+		rest: jest.fn(),
+	},
+	settings: require("../../../src/index").settings,
+	logger: MockLogger(),
+	sendError: jest.fn(),
+	send404: jest.fn(),
+});
+
+const MockRequest = () => Object.assign(jest.fn(), {headers: {}});
+
+describe("WebGateway", () => {
+	describe("methods", () => {
+		describe("httpHandler", () => {
+			it("is a function", () => {
+				expect(typeof HttpHandler()).toEqual("function");
+			});
+
+			it("sets $startTime of the request to the current process.hrtime()", () => {
+				const handler = HttpHandler();
+				const req = MockRequest();
+				const res = jest.fn();
+				const next = jest.fn();
+				const context = MockContext();
+				context.actions.rest.mockReturnValueOnce(Promise.resolve());
+
+				return handler.bind(context)(req, res, next).then(() => {
+					expect(req.$startTime[0]).toBeLessThanOrEqual(process.hrtime()[0]);
+				});
+			});
+
+			it("references the context via req.$service and res.$service", () => {
+				const handler = HttpHandler();
+				const req = MockRequest();
+				const res = jest.fn();
+				const next = jest.fn();
+				const context = MockContext();
+				context.actions.rest.mockReturnValueOnce(Promise.resolve());
+
+				return handler.bind(context)(req, res, next).then(() => {
+					expect(req.$service).toEqual(context);
+					expect(res.$service).toEqual(context);
+				});
+			});
+
+			it("references the next middleware callback via req.$next", () => {
+				const handler = HttpHandler();
+				const req = MockRequest();
+				const res = jest.fn();
+				const next = jest.fn();
+				const context = MockContext();
+				context.actions.rest.mockReturnValueOnce(Promise.resolve());
+
+				return handler.bind(context)(req, res, next).then(() => {
+					expect(req.$next).toEqual(next);
+				});
+			});
+
+			it("ensures that res.locals is an object if undefined", () => {
+				const handler = HttpHandler();
+				const req = MockRequest();
+				const res = jest.fn();
+				const next = jest.fn();
+				const context = MockContext();
+				context.actions.rest.mockReturnValueOnce(Promise.resolve());
+
+				return handler.bind(context)(req, res, next).then(() => {
+					expect(res.locals).toEqual({});
+				});
+			});
+
+			it("maintains the requestId of a \"x-request-id\" header if present", () => {
+				const handler = HttpHandler();
+				const req = MockRequest();
+				req.headers["x-request-id"] = "foobar";
+				const res = jest.fn();
+				const next = jest.fn();
+				const context = MockContext();
+				context.actions.rest.mockReturnValueOnce(Promise.resolve());
+
+				return handler.bind(context)(req, res, next).then(() => {
+					expect(context.actions.rest.mock.calls[0]).toEqual([{req, res}, {requestID: "foobar"}]);
+				});
+			});
+
+			it("maintains the requestId of a \"x-correlation-id\" header if present", () => {
+				const handler = HttpHandler();
+				const req = MockRequest();
+				req.headers["x-request-id"] = "foobar";
+				req.headers["x-correlation-id"] = "barfoo";
+				const res = jest.fn();
+				const next = jest.fn();
+				const context = MockContext();
+				context.actions.rest.mockReturnValueOnce(Promise.resolve());
+
+				return handler.bind(context)(req, res, next).then(() => {
+					expect(context.actions.rest.mock.calls[0]).toEqual([{req, res}, {requestID: "barfoo"}]);
+				});
+			});
+
+			it("resolves if the rest.action did resolve with an object result", () => {
+				const handler = HttpHandler();
+				const req = MockRequest();
+				const res = jest.fn();
+				const next = jest.fn();
+				const context = MockContext();
+				context.actions.rest.mockReturnValueOnce(Promise.resolve({foo: "bar"}));
+
+				return handler.bind(context)(req, res, next).then(result => {
+					expect(context.send404.mock.calls.length).toEqual(0);
+				});
+			});
+
+			it("sends a 404 response if the request could not be routed and serving static assets is not configured", () => {
+				const handler = HttpHandler();
+				const req = MockRequest();
+				const res = jest.fn();
+				const next = jest.fn();
+				const context = MockContext();
+				context.actions.rest.mockReturnValueOnce(Promise.resolve(null));
+
+				return handler.bind(context)(req, res, next).then(result => {
+					expect(context.send404.mock.calls[0]).toEqual([req, res]);
+				});
+			});
+
+			it("resolves if the request could not be routed and instead a static asset was served", () => {
+				const handler = HttpHandler();
+				const req = MockRequest();
+				const res = jest.fn();
+				const next = jest.fn();
+				let context = MockContext();
+				context.serve = jest.fn();
+				context.actions.rest.mockReturnValueOnce(Promise.resolve(null));
+
+				return handler.bind(context)(req, res, next).then(() => {
+					expect(context.send404.mock.calls.length).toEqual(0);
+					expect(context.serve.mock.calls[0][0]).toEqual(req);
+					expect(context.serve.mock.calls[0][1]).toEqual(res);
+				});
+			});
+
+			it("responds with 404 if the request could not be routed and serving a static asset encountered an error", () => {
+				const handler = HttpHandler();
+				const req = MockRequest();
+				const res = jest.fn();
+				const next = jest.fn();
+				let context = MockContext();
+				const error = new Error("Something went wrong while serving a static asset");
+				context.serve = jest.fn();
+				context.actions.rest.mockReturnValueOnce(Promise.resolve(null));
+
+				return handler.bind(context)(req, res, next).then(() => {
+					context.serve.mock.calls[0][2](error);
+					expect(context.send404.mock.calls[0]).toEqual([req, res]);
+					expect(context.logger.debug.mock.calls[0]).toEqual([error]);
+				});
+			});
+
+			it("logs and responds with an error if the rest action rejects", () => {
+				const handler = HttpHandler();
+				const req = MockRequest();
+				const res = jest.fn();
+				const next = jest.fn();
+				const context = MockContext();
+				let error = new Error("Something went wrong while invoking the rest action");
+				error.code = 419;
+				context.actions.rest.mockReturnValueOnce(Promise.reject(error));
+
+				return handler.bind(context)(req, res, next).then(() => {
+					expect(context.sendError.mock.calls[0]).toEqual([req, res, error]);
+					expect(context.logger.error.mock.calls[0]).toEqual(["   Request error!", error.name, ":", error.message, "\n", error.stack, "\nData:", error.data]);
+				});
+			});
+
+			it("responds with an error but does not log the error if the rest action rejects, the error code is 400 and settings.log4XXResponses is false", () => {
+				const handler = HttpHandler();
+				const req = MockRequest();
+				const res = jest.fn();
+				const next = jest.fn();
+				const context = MockContext();
+				context.settings.log4XXResponses = false;
+				let error = new Error("Something went wrong while invoking the rest action");
+				error.code = 400;
+				context.actions.rest.mockReturnValueOnce(Promise.reject(error));
+
+				return handler.bind(context)(req, res, next).then(() => {
+					expect(context.sendError.mock.calls[0]).toEqual([req, res, error]);
+					expect(context.logger.error.mock.calls.length).toEqual(0);
+				});
+			});
+
+			it("logs and responds with an error if the rest action rejects, the error code is 399 and settings.log4XXResponses is false", () => {
+				const handler = HttpHandler();
+				const req = MockRequest();
+				const res = jest.fn();
+				const next = jest.fn();
+				const context = MockContext();
+				context.settings.log4XXResponses = false;
+				let error = new Error("Something went wrong while invoking the rest action");
+				error.code = 399;
+				context.actions.rest.mockReturnValueOnce(Promise.reject(error));
+
+				return handler.bind(context)(req, res, next).then(() => {
+					expect(context.sendError.mock.calls[0]).toEqual([req, res, error]);
+					expect(context.logger.error.mock.calls.length).toEqual(1);
+				});
+			});
+
+			it("logs and responds with an error if the rest action rejects, the error code is 500 and settings.log4XXResponses is false", () => {
+				const handler = HttpHandler();
+				const req = MockRequest();
+				const res = jest.fn();
+				const next = jest.fn();
+				const context = MockContext();
+				context.settings.log4XXResponses = false;
+				let error = new Error("Something went wrong while invoking the rest action");
+				error.code = 500;
+				context.actions.rest.mockReturnValueOnce(Promise.reject(error));
+
+				return handler.bind(context)(req, res, next).then(() => {
+					expect(context.sendError.mock.calls[0]).toEqual([req, res, error]);
+					expect(context.logger.error.mock.calls.length).toEqual(1);
+				});
+			});
+		});
+	});
+});


### PR DESCRIPTION
* adds a new setting `log4XXResponses`. Default is true for backwards compability
* when `log4XXResponses` is set to false and an action rejected with a 4XX status code, the error will not be logged on error level (refer to https://github.com/moleculerjs/moleculer-web/issues/76)
* adapts the full example to include setting this option for documentation purpose
* adds unit tests for the `httpHandler` method