### PR TITLE
Replace ~ only at the beginning of URL path (eg. "~node")

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -305,7 +305,8 @@ module.exports = {
 						if (urlPath.startsWith("/"))
 							urlPath = urlPath.slice(1);
 
-						urlPath = urlPath.replace(/~/, "$");
+						// Resolve $node service
+						urlPath = urlPath.replace(/^~/, "$");
 						let action = urlPath;
 
 						// Resolve aliases

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -856,6 +856,25 @@ describe("Test aliases", () => {
 			});
 	});
 
+	it("GET /api/greeter/~Tilde~", () => {
+		return request(server)
+			.get("/api/greeter/~Tilde~")
+			.then(res => {
+				expect(res.statusCode).toBe(200);
+				expect(res.headers["content-type"]).toBe("application/json; charset=utf-8");
+				expect(res.body).toBe("Hello ~Tilde~");
+			});
+	});
+
+	it("GET /api/~node/health", () => {
+		return request(server)
+			.get("/api/~node/health")
+			.then(res => {
+				expect(res.statusCode).toBe(200);
+				expect(res.headers["content-type"]).toBe("application/json; charset=utf-8");
+			});
+	});
+
 	it("POST /api/greeter/Norbert", () => {
 		return request(server)
 			.post("/api/greeter/Norbert")


### PR DESCRIPTION
I've noticed that the first `~` character in the request URL path is replaced by a `$` character. I assume this exists to support calling actions exposed by the internal `$node` service (see [here](https://moleculer.services/docs/0.13/services.html#Internal-services)), eg. `GET /~node/list` is calling the action `$node.list`. 

In our case this causes problems because we have a service exposing database records (using `moleculer-db`) containing a `~` in their ID and use the following alias:

```js
  aliases: {
    'GET contacts/:id': 'contacts.get'
  }
```

When calling `GET /contacts/ABC~123`, the `params.id` is `ABC$123` instead of `ABC~123`.

I've changed the regex to only replace the tilde from the beginning of the path, but I'm not sure if this breaks some other feature I might have missed.