### PR TITLE
Validate error code range on send error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -752,7 +752,7 @@ module.exports = {
 			// Return with the error as JSON object
 			res.setHeader("Content-type", "application/json; charset=utf-8");
 
-			const code = _.isNumber(err.code) && _.inRange(err.code, 400, 500) ? err.code : 500;
+			const code = _.isNumber(err.code) && _.inRange(err.code, 400, 599) ? err.code : 500;
 			res.writeHead(code);
 			const errObj = _.pick(err, ["name", "message", "code", "type", "data"]);
 			res.end(JSON.stringify(errObj, null, 2));

--- a/src/index.js
+++ b/src/index.js
@@ -752,7 +752,7 @@ module.exports = {
 			// Return with the error as JSON object
 			res.setHeader("Content-type", "application/json; charset=utf-8");
 
-			const code = _.isNumber(err.code) ? err.code : 500;
+			const code = _.isNumber(err.code) && _.inRange(err.code, 400, 500) ? err.code : 500;
 			res.writeHead(code);
 			const errObj = _.pick(err, ["name", "message", "code", "type", "data"]);
 			res.end(JSON.stringify(errObj, null, 2));


### PR DESCRIPTION
When an error has a code not in range 400 to 500 the res.writeHead(code) throws a RangeError and become a unhandled rejection and api gateway don't response at all
**Example error:**
`MongoError { code: 11000, message: E11000 duplicate key error collection: database.users index: email_1 dup key: { : \"name@example.com\" }}`