### PR TITLE
Fix REST shorthand alias setup

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -836,7 +836,7 @@ module.exports = {
 				else
 					time = chalk.grey(`[+${Number(duration).toFixed(3)} ms]`);
 			}
-			this.logger.info(`<= ${this.coloringStatusCode(res.statusCode)} ${req.method} ${chalk.bold(req.url)} ${time}`);
+			this.logger.info(`<= ${this.coloringStatusCode(res.statusCode)} ${req.method} ${chalk.bold(req.originalUrl)} ${time}`);
 
 			/* istanbul ignore next */
 			if (this.settings.logResponseData && this.settings.logResponseData in this.logger) {

--- a/src/index.js
+++ b/src/index.js
@@ -1201,7 +1201,7 @@ module.exports = {
 				create: `POST ${pathName}`,
 				update: `PUT ${pathNameWithoutEndingSlash}/:id`,
 				patch: `PATCH ${pathNameWithoutEndingSlash}/:id`,
-				remove: `DELETE ${pathNameWithoutEndingSlash}/:id`,
+				remove: `DELETE ${pathNameWithoutEndingSlash}/:id`
 			};
 			let actions = ["list", "get", "create", "update", "patch", "remove"];
 

--- a/src/index.js
+++ b/src/index.js
@@ -1194,13 +1194,14 @@ module.exports = {
 		generateRESTAliases(route, path, action) {
 			const p = path.split(/\s+/);
 			const pathName = p[1];
+            const pathNameWithoutEndingSlash = pathName.endsWith("/") ? pathName.slice(0, -1) : pathName;
 			const aliases = {
 				list: `GET ${pathName}`,
-				get: `GET ${pathName}/:id`,
+				get: `GET ${pathNameWithoutEndingSlash}/:id`,
 				create: `POST ${pathName}`,
-				update: `PUT ${pathName}/:id`,
-				patch: `PATCH ${pathName}/:id`,
-				remove: `DELETE ${pathName}/:id`,
+				update: `PUT ${pathNameWithoutEndingSlash}/:id`,
+				patch: `PATCH ${pathNameWithoutEndingSlash}/:id`,
+				remove: `DELETE ${pathNameWithoutEndingSlash}/:id`,
 			};
 			let actions = ["list", "get", "create", "update", "patch", "remove"];
 


### PR DESCRIPTION
If you setup a service in this way:
```
module.exports = {
    name: 'api',
    mixins: [
        MoleculerWeb
    ],
    settings: {
        path: '/',
        routes: [{
            path: '/users',
            mappingPolicy: 'restrict',
            aliases: {
                'REST /': 'users'
            }
        }]
    }
};
```
The inferred aliases will be wrong. This is what will be logged in console:

> GET /users => users.list
> GET /users//:id => users.get
> POST /users => users.create
> PUT /users//:id => users.update
> PATCH /users//:id => users.patch
> DELETE /users//:id => users.remove

With the proposed fix, the aliases will be correctly generated. This is the new logged lines:

> GET /users => users.list
> GET /users/:id => users.get
> POST /users => users.create
> PUT /users/:id => users.update
> PATCH /users/:id => users.patch
> DELETE /users/:id => users.remove

