### PR TITLE
Add option to change `basePath` on action level for AutoAliases

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1334,10 +1334,10 @@ module.exports = {
 								};
 							}
 						} else if (_.isObject(action.rest)) {
-							// Handle route: { method: "POST", path: "/other" }
+							// Handle route: { method: "POST", path: "/other", basePath: "newBasePath" }
 							alias = Object.assign({}, action.rest, {
 								method: action.rest.method || "*",
-								path: basePath + (action.rest.path ? action.rest.path : action.rawName)
+								path: (action.rest.basePath ? action.rest.basePath : basePath) + (action.rest.path ? action.rest.path : action.rawName)
 							});
 						}
 

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -3583,14 +3583,15 @@ describe("Test auto aliasing", () => {
 	}
 
 	beforeAll(() => {
-		[ broker, service, server] = setup({
+		[broker, service, server] = setup({
 			routes: [
 				{
 					path: "api",
 					whitelist: [
 						"posts.*",
 						"test.hello",
-						"test.full*"
+						"test.full*",
+						"test.base*"
 					],
 
 					autoAliases: true,
@@ -3707,13 +3708,28 @@ describe("Test auto aliasing", () => {
 			});
 	});
 
-	it("should call 'GET /api/hi'", () => {
+	it("should call 'GET /api/custom-base-path/base-path'", () => {
 		return request(server)
-			.get("/api/hi")
+			.get("/api/custom-base-path/base-path")
 			.then(res => {
 				expect(res.statusCode).toBe(200);
 				expect(res.headers["content-type"]).toBe("application/json; charset=utf-8");
-				expect(res.body).toBe("Hello Moleculer");
+				expect(res.body).toBe("Hello Custom Moleculer Root Path");
+			});
+	});
+
+	it("should not call 'GET /api/custom-base-path/base-path-error'", () => {
+		return request(server)
+			.get("/api/custom-base-path/base-path-error")
+			.then(res => {
+				expect(res.statusCode).toBe(404);
+				expect(res.headers["content-type"]).toBe("application/json; charset=utf-8");
+				expect(res.body).toEqual({
+					"code": 404,
+					"message": "Not found",
+					"name": "NotFoundError",
+					"type": "NOT_FOUND"
+				});
 			});
 	});
 

--- a/test/services/test.service.js
+++ b/test/services/test.service.js
@@ -42,6 +42,27 @@ module.exports = {
 			}
 		},
 
+		basePath: {
+			rest: {
+				method: "GET",
+				path: "/base-path",
+				basePath: "custom-base-path"
+			},
+			handler(ctx) {
+				return "Hello Custom Moleculer Root Path";
+			}
+		},
+
+		basePathError: {
+			rest: {
+				method: "GET",
+				path: "/base-path-error"
+			},
+			handler(ctx) {
+				return "Hello Custom Moleculer Root Path with Error";
+			}
+		},
+
 		whoami: {
 			handler(ctx) {
 				if (ctx.meta.user) {


### PR DESCRIPTION
Currently, we can define/change `basePath` only on service level using `service.settings.rest`. This PR will add an option to define action-specific `basePath`.