### PR TITLE
remove empty log

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -970,7 +970,6 @@ module.exports = {
 			if (this.settings.logResponseData && this.settings.logResponseData in this.logger) {
 				this.logger[this.settings.logResponseData]("  Data:", data);
 			}
-			this.logger.info("");
 		},
 
 		/**


### PR DESCRIPTION
After logging a call's response, an empty message gets logged. This looks fine in a console logger, but when json logs are streamed to an aggregation service (e.g. Datadog) this empty log is unnecessary and meaningless noise. This PR removes it.