### PR TITLE
Class constructor BadRequestError cannot be invoked without 'new'.

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -22,7 +22,7 @@ function decodeParam(param) {
 		return decodeURIComponent(param);
 	} catch (_) {
 		/* istanbul ignore next */
-		throw BadRequestError(ERR_UNABLE_DECODE_PARAM, { param });
+		throw new BadRequestError(ERR_UNABLE_DECODE_PARAM, { param });
 	}
 }
 


### PR DESCRIPTION
Class constructor BadRequestError cannot be invoked without 'new'.

```
TypeError: Class constructor BadRequestError cannot be invoked without 'new'
    at decodeParam (/app/node_modules/moleculer-web/src/utils.js:25:9)
    at Alias.match (/app/node_modules/moleculer-web/src/alias.js:108:23)
    at Object.resolveAlias (/app/node_modules/moleculer-web/src/index.js:1103:27)
    at Object.handler (/app/node_modules/moleculer-web/src/index.js:198:24)
    at /app/node_modules/moleculer/src/utils.js:131:22
    at ServiceBroker.timeoutMiddleware (/app/node_modules/moleculer/src/middlewares/timeout.js:35:14)
    at ServiceBroker.fallbackMiddleware (/app/node_modules/moleculer/src/middlewares/fallback.js:29:11)
    at ServiceBroker.errorHandlerMiddleware (/app/node_modules/moleculer/src/middlewares/error-handler.js:14:10)
    at ServiceBroker.tracingLocalActionMiddleware (/app/node_modules/moleculer/src/middlewares/tracing.js:84:12)
    at Object.actions.<computed> [as rest] (/app/node_modules/moleculer/src/service.js:149:13) 
```