### PR TITLE
(feat) allow cors to reflect origin

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1001,7 +1001,7 @@ module.exports = {
 			// Access-Control-Allow-Origin
 			if (!route.cors.origin || route.cors.origin === "*") {
 				res.setHeader("Access-Control-Allow-Origin", "*");
-			} else if (this.checkOrigin(origin, route.cors.origin)) {
+			} else if (route.cors.origin === true || this.checkOrigin(origin, route.cors.origin)) {
 				res.setHeader("Access-Control-Allow-Origin", origin);
 				res.setHeader("Vary", "Origin");
 			} else {

--- a/src/index.js
+++ b/src/index.js
@@ -950,35 +950,6 @@ module.exports = {
 		},
 
 		/**
-		 * Check origin(s)
-		 *
-		 * @param {String} origin
-		 * @param {String|Array<String>} settings
-		 * @returns {Boolean}
-		 */
-		checkOrigin(origin, settings) {
-			if (_.isString(settings)) {
-				if (settings.indexOf(origin) !== -1)
-					return true;
-
-				if (settings.indexOf("*") !== -1) {
-					// Based on: https://github.com/hapijs/hapi
-					// eslint-disable-next-line
-					const wildcard = new RegExp(`^${_.escapeRegExp(settings).replace(/\\\*/g, ".*").replace(/\\\?/g, ".")}$`);
-					return origin.match(wildcard);
-				}
-			} else if (Array.isArray(settings)) {
-				for (let i = 0; i < settings.length; i++) {
-					if (this.checkOrigin(origin, settings[i])) {
-						return true;
-					}
-				}
-			}
-
-			return false;
-		},
-
-		/**
 		 * Write CORS header
 		 *
 		 * Based on: https://github.com/expressjs/cors
@@ -989,7 +960,6 @@ module.exports = {
 		 * @param {Boolean} isPreFlight
 		 */
 		writeCorsHeaders(route, req, res, isPreFlight) {
-
 			/* istanbul ignore next */
 			if (!route.cors) return;
 
@@ -998,15 +968,32 @@ module.exports = {
 			if (!origin)
 				return;
 
+			let policy = null;
+			let strict = true;
+
+			const checkOrigin = (candidate) => (
+				_.isArray(candidate) ? _.find(route.cors.origin, checkOrigin) : 
+				_.isString(candidate)	? origin === candidate :
+				_.isRegExp(candidate) ? candidate.test(origin) :
+				false
+			)
+
 			// Access-Control-Allow-Origin
-			if (!route.cors.origin || route.cors.origin === "*") {
-				res.setHeader("Access-Control-Allow-Origin", "*");
-			} else if (route.cors.origin === true || this.checkOrigin(origin, route.cors.origin)) {
-				res.setHeader("Access-Control-Allow-Origin", origin);
-				res.setHeader("Vary", "Origin");
-			} else {
+			if (route.cors.origin === true) {
+				policy = "*";
+				strict = true;
+			}
+			else if (checkOrigin(route.cors.origin)) {
+				policy = origin;
+				strict = false;
+			}
+			
+			if (!policy) {
 				throw new ForbiddenError(ERR_ORIGIN_NOT_ALLOWED);
 			}
+
+			res.setHeader("Access-Control-Allow-Origin", policy);
+			if (!strict) res.setHeader("Vary", "Origin");
 
 			// Access-Control-Allow-Credentials
 			if (route.cors.credentials === true) {
@@ -1218,7 +1205,6 @@ module.exports = {
 			if (this.settings.cors || opts.cors) {
 				// Merge cors settings
 				route.cors = Object.assign({}, {
-					origin: "*",
 					methods: ["GET", "HEAD", "PUT", "PATCH", "POST", "DELETE"]
 				}, this.settings.cors, opts.cors);
 			} else {

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -2125,77 +2125,120 @@ describe("Test CORS", () => {
 			}).then(() => broker.stop()).catch(err => broker.stop().then(() => { throw err; }));
 	});
 
-	it("errors on mismatching origin header", () => {
-		[broker, service, server] = setup({
-			cors: {
-				origin: "a"
-			}
-		});
-		return broker.start()
-			.then(() => request(server)
-				.get("/test/hello")
-				.set("Origin", "http://localhost:3000"))
-			.then(res => {
-				expect(res.statusCode).toBe(403);
-				expect(res.body).toEqual({
-					"message": "Forbidden",
-					"code": 403,
-					"type": "ORIGIN_NOT_ALLOWED",
-					"name": "ForbiddenError"
-				});
-			}).then(() => broker.stop()).catch(err => broker.stop().then(() => { throw err; }));
-	});
-
+	// breaking change /!\ default is super secure now. no cors means... no cors.
 	it("with default settings", () => {
 		[broker, service, server] = setup({
-			cors: {}
+			cors: {},
 		});
 
-		return broker.start()
-			.then(() => request(server)
-				.get("/test/hello")
-				.set("Origin", "http://localhost:3000"))
-			.then(res => {
-				expect(res.statusCode).toBe(200);
-				expect(res.headers["content-type"]).toBe("application/json; charset=utf-8");
-				expect(res.headers["access-control-allow-origin"]).toBe("*");
-
-				expect(res.body).toBe("Hello Moleculer");
+		return broker
+			.start()
+			.then(() =>
+				request(server)
+					.get("/test/hello")
+					.set("Origin", "http://localhost:3000")
+			)
+			.then((res) => {
+				expect(res.statusCode).toBe(403);
+				expect(res.body).toEqual({
+					message: "Forbidden",
+					code: 403,
+					type: "ORIGIN_NOT_ALLOWED",
+					name: "ForbiddenError",
+				});
 			})
-			.then(() => broker.stop()).catch(err => broker.stop().then(() => { throw err; }));
+			.then(() => broker.stop())
+			.catch((err) =>
+				broker.stop().then(() => {
+					throw err;
+				})
+			);
+	});
+
+	it("with custom global settings (boolean)", () => {
+		[broker, service, server] = setup({
+			cors: {
+				origin: true,
+			},
+		});
+
+		return broker
+			.start()
+			.then(() =>
+				request(server)
+					.get("/test/hello")
+					.set("Origin", "http://localhost:3000")
+			)
+			.then((res) => {
+				expect(res.statusCode).toBe(200);
+				expect(res.headers["access-control-allow-origin"]).toBe("*");
+			})
+			.then(() => broker.stop())
+			.catch((err) =>
+				broker.stop().then(() => {
+					throw err;
+				})
+			);
 	});
 
 	it("with custom global settings (string)", () => {
 		[broker, service, server] = setup({
 			cors: {
 				origin: "http://localhost:3000",
-				exposedHeaders: "X-Response-Time",
-				credentials: true
-			}
+			},
 		});
 
-		return broker.start()
-			.then(() => request(server)
-				.get("/test/hello")
-				.set("Origin", "http://localhost:3000"))
-			.then(res => {
+		return broker
+			.start()
+			.then(() =>
+				request(server)
+					.get("/test/hello")
+					.set("Origin", "http://localhost:3000")
+			)
+			.then((res) => {
 				expect(res.statusCode).toBe(200);
-				expect(res.headers["content-type"]).toBe("application/json; charset=utf-8");
 				expect(res.headers["access-control-allow-origin"]).toBe("http://localhost:3000");
-				expect(res.headers["access-control-allow-credentials"]).toBe("true");
-				expect(res.headers["access-control-expose-headers"]).toBe("X-Response-Time");
-
-				expect(res.body).toBe("Hello Moleculer");
+				expect(res.headers["vary"]).toBe("Origin");
 			})
-			.then(() => broker.stop()).catch(err => broker.stop().then(() => { throw err; }));
+			.then(() => broker.stop())
+			.catch((err) =>
+				broker.stop().then(() => {
+					throw err;
+				})
+			);
 	});
+
+it("with custom global settings (regexp)", () => {
+	[broker, service, server] = setup({
+		cors: {
+			origin: /localhost/,
+		},
+	});
+
+	return broker
+		.start()
+		.then(() =>
+			request(server)
+				.get("/test/hello")
+				.set("Origin", "http://localhost:3000")
+		)
+		.then((res) => {
+			expect(res.statusCode).toBe(200);
+			expect(res.headers["access-control-allow-origin"]).toBe("http://localhost:3000");
+			expect(res.headers["vary"]).toBe("Origin");
+		})
+		.then(() => broker.stop())
+		.catch((err) =>
+			broker.stop().then(() => {
+				throw err;
+			})
+		);
+	});		
 
 	it("with custom global settings (array)", () => {
 		[broker, service, server] = setup({
 			cors: {
-				origin: ["http://localhost:3000", "https://localhost:4000"],
-				exposedHeaders: ["X-Custom-Header", "X-Response-Time"],
-				credentials: true
+				origin: ["http://localhost:3000", /^https/],
 			}
 		});
 
@@ -2205,15 +2248,41 @@ describe("Test CORS", () => {
 				.set("Origin", "https://localhost:4000"))
 			.then(res => {
 				expect(res.statusCode).toBe(200);
-				expect(res.headers["content-type"]).toBe("application/json; charset=utf-8");
 				expect(res.headers["access-control-allow-origin"]).toBe("https://localhost:4000");
-				expect(res.headers["access-control-allow-credentials"]).toBe("true");
-				expect(res.headers["access-control-expose-headers"]).toBe("X-Custom-Header, X-Response-Time");
-
-				expect(res.body).toBe("Hello Moleculer");
+				expect(res.headers["vary"]).toBe("Origin");
 			})
 			.then(() => broker.stop()).catch(err => broker.stop().then(() => { throw err; }));
 	});
+
+	it("errors on mismatching origin header", () => {
+	[broker, service, server] = setup({
+		cors: {
+			origin: "a",
+		},
+	});
+	return broker
+		.start()
+		.then(() =>
+			request(server)
+				.get("/test/hello")
+				.set("Origin", "http://localhost:3000")
+		)
+		.then((res) => {
+			expect(res.statusCode).toBe(403);
+			expect(res.body).toEqual({
+				message: "Forbidden",
+				code: 403,
+				type: "ORIGIN_NOT_ALLOWED",
+				name: "ForbiddenError",
+			});
+		})
+		.then(() => broker.stop())
+		.catch((err) =>
+			broker.stop().then(() => {
+				throw err;
+			})
+		);
+	});	
 
 	it("with custom route settings", () => {
 		[broker, service, server] = setup({
@@ -2240,72 +2309,6 @@ describe("Test CORS", () => {
 				expect(res.headers["content-type"]).toBe("application/json; charset=utf-8");
 				expect(res.headers["access-control-allow-origin"]).toBe("http://test-server");
 				expect(res.headers["access-control-expose-headers"]).toBe("X-Response-Time");
-
-				expect(res.body).toBe("Hello Moleculer");
-			})
-			.then(() => broker.stop()).catch(err => broker.stop().then(() => { throw err; }));
-	});
-
-	it("returns matching CORS origin wildcard with single origin", () => {
-		[broker, service, server] = setup({
-			cors: {
-				origin: "http://localhost:*",
-			}
-		});
-
-		return broker.start()
-			.then(() => request(server)
-				.get("/test/hello")
-				.set("Origin", "http://localhost:4000"))
-			.then(res => {
-				expect(res.statusCode).toBe(200);
-				expect(res.headers["content-type"]).toBe("application/json; charset=utf-8");
-				expect(res.headers["access-control-allow-origin"]).toBe("http://localhost:4000");
-				expect(res.headers["vary"]).toBe("Origin");
-
-				expect(res.body).toBe("Hello Moleculer");
-			})
-			.then(() => broker.stop()).catch(err => broker.stop().then(() => { throw err; }));
-	});
-
-	it("returns matching CORS origin wildcard", () => {
-		[broker, service, server] = setup({
-			cors: {
-				origin: ["http://test.example.com", "http://www.example.com", "http://*.a.com"],
-			}
-		});
-
-		return broker.start()
-			.then(() => request(server)
-				.get("/test/hello")
-				.set("Origin", "http://www.a.com"))
-			.then(res => {
-				expect(res.statusCode).toBe(200);
-				expect(res.headers["content-type"]).toBe("application/json; charset=utf-8");
-				expect(res.headers["access-control-allow-origin"]).toBe("http://www.a.com");
-				expect(res.headers["vary"]).toBe("Origin");
-
-				expect(res.body).toBe("Hello Moleculer");
-			})
-			.then(() => broker.stop()).catch(err => broker.stop().then(() => { throw err; }));
-	});
-
-	it("returns matching CORS origin wildcard when more than one wildcard", () => {
-		[broker, service, server] = setup({
-			cors: {
-				origin: ["http://test.example.com", "http://*.b.com", "http://*.a.com"],
-			}
-		});
-
-		return broker.start()
-			.then(() => request(server)
-				.get("/test/hello")
-				.set("Origin", "http://www.a.com"))
-			.then(res => {
-				expect(res.statusCode).toBe(200);
-				expect(res.headers["content-type"]).toBe("application/json; charset=utf-8");
-				expect(res.headers["access-control-allow-origin"]).toBe("http://www.a.com");
-				expect(res.headers["vary"]).toBe("Origin");
 
 				expect(res.body).toBe("Hello Moleculer");
 			})
@@ -2352,6 +2355,7 @@ describe("Test CORS", () => {
 	it("preflight request with default settings", () => {
 		[broker, service, server] = setup({
 			cors: {
+				origin: true,
 				allowedHeaders: ["X-Custom-Header", "X-Response-Time"]
 			}
 		});


### PR DESCRIPTION
Hello !

Just a small and simple PR to propose to follow up on your implementation of CORS checking. As you mentioned in the comment, it is following the express cors middleware, but missing one key feature: the ability to reflect origin when passing `true` as a setting value. You can find documentation [here](https://expressjs.com/en/resources/middleware/cors.html#configuration-options) about it.

As currently developing an api, the team i work with is really dependent on this. We need to allow local development (with localhost) to target our dev environment (not localhost) along with passing credentials (withCredentials: true) in our requests. As you may know, settings cors to `*` won't do in that case, and we were hoping to find this feature here.

Let me know if some things are missing in this PR so we can move forward.