### PR TITLE
sanitize properties from response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2440,6 +2440,16 @@
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "blob": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
@@ -5197,6 +5207,13 @@
       "requires": {
         "flat-cache": "^2.0.1"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "fill-range": {
       "version": "7.0.1",
@@ -8563,6 +8580,13 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -12835,7 +12859,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2440,16 +2440,6 @@
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "dev": true
     },
-    "bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
     "blob": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
@@ -5207,13 +5197,6 @@
       "requires": {
         "flat-cache": "^2.0.1"
       }
-    },
-    "file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "dev": true,
-      "optional": true
     },
     "fill-range": {
       "version": "7.0.1",
@@ -8580,13 +8563,6 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
-    },
-    "nan": {
-      "version": "2.14.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
-      "dev": true,
-      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -12859,11 +12835,7 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "nan": "^2.12.1"
-          }
+          "optional": true
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/test/services/user.service.js
+++ b/test/services/user.service.js
@@ -1,0 +1,42 @@
+"use strict";
+
+const _ = require("lodash");
+
+const users = [{
+    id: "unique-user-id-1",
+    password: "secret-password",
+    name: "username-1",
+    setting: {
+        id: "unique-settings-id1",
+        privateKey: "super-secret-private-key"
+    }
+}, {
+    id: "unique-user-id-2",
+    password: "secret-password",
+    name: "username-2",
+    setting: {
+        id: "unique-settings-id2",
+        privateKey: "super-secret-private-key"
+    }
+}];
+
+module.exports = {
+    name: "users",
+
+    actions: {
+        list: {
+            rest: "GET /",
+            sanitize: ["password", { from: "id", to: "userId" }, "setting.privateKey", { from: "setting.id", to: "setting.settingId" }],
+            handler(ctx) {
+                return users;
+            }
+        },
+        get: {
+            rest: "GET /:id",
+            sanitize: ["password", { from: "id", to: "userId" }, "setting.privateKey", { from: "setting.id", to: "setting.settingId" }],
+            handler(ctx) {
+                return users.find(u => u.id === ctx.params.id);
+            }
+        }
+    }
+};


### PR DESCRIPTION
On your moleculer action you can set the **sanitize** property. It is an array of strings or objects, which is used to sanitize the REST response.
If the parameter in the array is a string, it will be removed from the response.
If the parameter is an object the property name will be updated from the old one to the new one.

For example: You have an user object. And on this object, the password from the user is present. But you don't want to send it back to the user:
```js
let user = {
  id: "userId",
  name: "name",
  password: "super-secret-password"
}
```

In your moleculer action, provide the sanitize param, to know which properties should be removed or updated.

```js
actions: {
  getUser: {
    ...
    sanitize: ["password", {from: "id", to: "userId"}]
    handler(ctx) { ... }
  }
}
```

The response looks like this:

```js
let user = {
  userId: "userId",
  name: "name"
}
```

If the response is an array, the sanitizing is done for each object.

It works also with nested objects:

```js
let user = {
  id: "userId",
  name: "name",
  password: "super-secret-password",
  setting: {
    id: "settingId",
    privateKey: "super-secret-private-key"
  }
}
```

For nested object, the nested string is given by dot-notation:
```js
actions: {
  getUser: {
    ...
    sanitize: ["password", {from: "id", to: "userId"}, "setting.privateKey", {from: "setting.id", to: "setting.settingId"}]
    handler(ctx) { ... }
  }
}
```