### PR TITLE
fix: clean old aliases on route update

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1309,7 +1309,7 @@ module.exports = {
 		 */
 		createRouteAliases(route, aliases) {
 			// Clean previous aliases for this route
-			this.aliases = this.aliases.filter(a => a.route != route);
+			this.aliases = this.aliases.filter(a => a.route.path != route.path);
 
 			// Process aliases definitions from route settings
 			_.forIn(aliases, (action, matchPath) => {

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -3603,6 +3603,38 @@ describe("Test dynamic routing", () => {
 				expect(res.body).toBe("Hello Moleculer");
 			});
 	});
+
+	it("change route should replace aliases & find '/my/helloagain'", () => {
+		service.addRoute({
+			path: "/my",
+			aliases: {
+				"helloagain": "test.hello"
+			}
+		});
+
+		return request(server)
+			.get("/my/helloagain")
+			.then(res => {
+				expect(res.statusCode).toBe(200);
+				expect(res.headers["content-type"]).toBe("application/json; charset=utf-8");
+				expect(res.body).toBe("Hello Moleculer");
+			});
+	});
+
+	it("but should not find '/my/hello'", () => {
+		return request(server)
+			.get("/my/hello")
+			.then(res => {
+				expect(res.statusCode).toBe(404);
+				expect(res.headers["content-type"]).toBe("application/json; charset=utf-8");
+				expect(res.body).toEqual({
+					"code": 404,
+					"message": "Not found",
+					"name": "NotFoundError",
+					"type": "NOT_FOUND"
+				});
+			});
+	});
 });
 
 


### PR DESCRIPTION
This fixes a bug where the route's aliases were not replaced on route update. The object stored in the alias's `route` property is the old route, which was being compared to the newly created route using object equality.