### PR TITLE
Fix url params to transfer at streaming

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,7 +13,7 @@ module.exports = {
 	],
 	"parserOptions": {
 		"sourceType": "module",
-		"ecmaVersion": "2017"
+		"ecmaVersion": "2018"
 	},
 	"plugins": [
 		"promise",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,7 +4,6 @@
 	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
 	"version": "0.2.0",
 	"configurations": [
-
 		{
 			"type": "node",
 			"request": "launch",
@@ -26,6 +25,15 @@
 			"runtimeArgs": [
                 "--nolazy"
             ]
-		}
+		},
+		{
+			"name": "Attach by Process ID",
+			"processId": "${command:PickProcess}",
+			"request": "attach",
+			"skipFiles": [
+				"<node_internals>/**"
+			],
+			"type": "pwa-node"
+		},
 	]
 }

--- a/examples/file.service.js
+++ b/examples/file.service.js
@@ -46,6 +46,7 @@ module.exports = {
 
 		save: {
 			handler(ctx) {
+				this.logger.info("Received upload $params:", ctx.meta.$params);
 				return new this.Promise((resolve, reject) => {
 					//reject(new Error("Disk out of space"));
 					const filePath = path.join(uploadDir, ctx.meta.filename || this.randomName());
@@ -71,13 +72,6 @@ module.exports = {
 
 					ctx.params.pipe(f);
 				});
-			}
-		},
-
-		saveParams: {
-			handler(ctx) {
-				// get params from url
-				return ctx.params.$params;
 			}
 		}
 	},

--- a/examples/file/assets/index.html
+++ b/examples/file/assets/index.html
@@ -22,7 +22,8 @@
 <body>
 	<fieldset>
 		<legend>Single file upload</legend>
-		<form action="/upload/single" method="post" enctype="multipart/form-data">
+		<form action="/upload/single/1234" method="post" enctype="multipart/form-data">
+			<input type="text" name="name" id="name" value="Test User">
 			<p>Select image to upload:</p>
 			<input type="file" name="myfile" id="myfile">
 			<br/>
@@ -43,7 +44,7 @@
 		<p>Select image to upload:</p>
 		<input type="file" name="myJSFile" id="myJSFile">
 		<br/>
-		<button onclick="uploadPut('/upload')">Upload one image via AJAX</button>
+		<button onclick="uploadPut('/upload/1234')">Upload one image via AJAX</button>
 		<p id="responseOK" style="color: green; font-weight: bold"></p>
 		<p id="responseError" style="color: red; font-weight: bold"></p>
 	</fieldset>
@@ -62,7 +63,7 @@
 		req.setRequestHeader("Content-type", "image/png");
 		req.onload = function(event) {
 			if (event.target.status == 200)
-				return pOK.innerHTML ="Uploaded successfully! Path: " + JSON.parse(event.target.responseText).filePath;
+				return pOK.innerHTML ="Uploaded successfully! " + event.target.responseText;
 
 			pError.innerHTML = "Upload error: " + event.target.responseText;
 		}

--- a/examples/file/index.js
+++ b/examples/file/index.js
@@ -50,13 +50,14 @@ broker.createService({
 					"PUT /": "stream:file.save",
 
 					// File upload from AJAX or cURL with params
-					"PUT /:id": "stream:file.saveParams",
+					"PUT /:id": "stream:file.save",
 
 					// File upload from HTML form and overwrite busboy config
-					"POST /single": {
+					"POST /single/:id": {
 						type: "multipart",
 						// Action level busboy config
 						busboyConfig: {
+							//empty: true,
 							limits: {
 								files: 1
 							},

--- a/src/alias.js
+++ b/src/alias.js
@@ -165,6 +165,7 @@ class Alias {
 				filename: filename,
 				encoding: encoding,
 				mimetype: mimetype,
+				$params: req.$params,
 			} })).catch(err => {
 				file.resume(); // Drain file stream to continue processing form
 				busboy.emit("error", err);

--- a/src/alias.js
+++ b/src/alias.js
@@ -148,6 +148,7 @@ class Alias {
 		const promises = [];
 
 		let numOfFiles = 0;
+		let hasField = false;
 
 		const busboyOptions = _.defaultsDeep({ headers: req.headers }, this.busboyConfig, this.route.opts.busboyConfig);
 		const busboy = new Busboy(busboyOptions);
@@ -173,6 +174,7 @@ class Alias {
 			}));
 		});
 		busboy.on("field", (field, value) => {
+			hasField = true;
 			ctx.meta.$multipart[field] = value;
 		});
 
@@ -180,6 +182,13 @@ class Alias {
 			/* istanbul ignore next */
 			if (!busboyOptions.empty && numOfFiles == 0)
 				return this.service.sendError(req, res, new MoleculerClientError("File missing in the request"));
+
+			// Call the action if no files but multipart fields
+			if (numOfFiles == 0 && hasField) {
+				promises.push(ctx.call(this.action, {}, _.defaultsDeep({}, this.route.opts.callOptions, { meta: {
+					$params: req.$params,
+				} })));
+			}
 
 			try {
 				let data = await this.service.Promise.all(promises);

--- a/src/index.js
+++ b/src/index.js
@@ -587,8 +587,15 @@ module.exports = {
 					params.$res = res;
 				}
 
+				const opts = route.callOptions ? { ...route.callOptions } : {};
+				if (params && params.$params) {
+					// Transfer URL parameters via meta in case of stream
+					if (!opts.meta) opts.meta = { $params: params.$params };
+					else opts.meta.$params = params.$params;
+				}
+
 				// Call the action
-				let data = await ctx.call(req.$endpoint, params, route.callOptions);
+				let data = await ctx.call(req.$endpoint, params, opts);
 
 				// Post-process the response
 
@@ -1502,7 +1509,7 @@ module.exports = {
 			return alias;
 		},
 
-				
+
 		/**
 		 * Set log level and log registration route related activities
 		 *
@@ -1515,7 +1522,7 @@ module.exports = {
 			)
 				this.logger[this.settings.logRouteRegistration](message);
 		},
-		
+
 	},
 
 	events: {


### PR DESCRIPTION
**Changes**
Access to the URL parameters (`/upload/:id`) via `ctx.meta.$params`. 

In the previous version only at `stream`-typed aliases, the `ctx.params.$params` works but only if the target service was on the same node as API gateway because the `params.$params` is not transferred. At multipart file upload, this doesn't work in any way.

**TODO**
- [ ] cover with tests.