### PR TITLE
Add named-routes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
 			"type": "node",
 			"request": "launch",
 			"name": "Launch demo",
-			"program": "${file}",
+			"program": "${workspaceRoot}/examples/dev/index.js",
 			"cwd": "${workspaceRoot}",
 			"env": {
 				"PORT": "3000"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,21 +16,21 @@ module.exports = {
         path: "/api",
 
         routes: [
-			{
-				name: "no-auth-route", // unique name
-				path: "/",
-				aliases: {
-					hi: "greeter.hello",
-				}
-			},
-			{
-				name: "with-auth-route", // unique name
-				path: "/",
-				aliases: {
-					"hello": "greeter.hello",
-				},
-				authorization: true
-			}
+            {
+                name: "no-auth-route", // unique name
+                path: "/",
+                aliases: {
+                    hi: "greeter.hello",
+                }
+            },
+            {
+                name: "with-auth-route", // unique name
+                path: "/",
+                aliases: {
+                    "hello": "greeter.hello",
+                },
+                authorization: true
+            }
         ]
     }
 };

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,46 @@
+<a name="0.10.2"></a>
+# 0.10.2 (2021-09-05)
+
+## Named routes
+Many developers issued that version 0.10 doesn't support multiple routes with the same path. This version fixes it but you should give a unique name for the routes if they have same path.
+
+**Example**
+You can call `/api/hi` without auth, but `/api/hello` only with auth.
+
+```js
+const ApiGateway = require("moleculer-web");
+
+module.exports = {
+    mixins: [ApiGateway],
+    settings: {
+        path: "/api",
+
+        routes: [
+			{
+				name: "no-auth-route", // unique name
+				path: "/",
+				aliases: {
+					hi: "greeter.hello",
+				}
+			},
+			{
+				name: "with-auth-route", // unique name
+				path: "/",
+				aliases: {
+					"hello": "greeter.hello",
+				},
+				authorization: true
+			}
+        ]
+    }
+};
+```
+
+## Changes
+- add `removeRouteByName(name: string)` method to remove a route by its name.
+
+
+-----------------------------
 <a name="0.10.1"></a>
 # 0.10.1 (2021-09-01)
 

--- a/examples/dev/index.js
+++ b/examples/dev/index.js
@@ -6,58 +6,44 @@ const ApiService 			= require("../../index");
 // Create broker
 const broker = new ServiceBroker();
 
-const FLAG_SAMPLED = 0x00000001;
-
 // Load API Gateway
 broker.createService({
 	name: "api",
 	mixins: [ApiService],
 	settings: {
-		routes: [{
-			path: "/api",
-			onBeforeCall(ctx) {
-				ctx.meta.a = 5;
+		path: "/api",
+		routes: [
+			{
+				name: "no-auth-route",
+				path: "/",
+				aliases: {
+					hi: "greeter.hello",
+				}
+			},
+			{
+				name: "only-auth-route",
+				path: "/",
+				aliases: {
+					"hello": "greeter.hello",
+				},
+				authorization: true
 			}
-		}],
-		/*rootCallOptions: {
-			timeout: 300
-		}*/
-		rootCallOptions(options, req, res) {
-			if (req.headers["traceparent"]) {
-				// More info https://www.w3.org/TR/trace-context/#traceparent-header
-				const traceparent = req.headers["traceparent"].toLowerCase();
-				if (traceparent.match(/^([0-9a-f]{2})-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$/)) {
-					const [version, id, parentSpan, flags] = traceparent.split("-");
-					const sampled = (flags & FLAG_SAMPLED) == FLAG_SAMPLED;
+		]
+	},
 
-					options.parentSpan = {
-						id: parentSpan,
-						traceID: id,
-						sampled
-					};
-				}
-			} else {
-				// Look for X-B3-Traceid, X-B3-Spanid
-				options.parentSpan = {};
-
-				if (req.headers["x-b3-traceid"]) {
-					options.parentSpan.traceID = req.headers["x-b3-traceid"].toLowerCase();
-					options.parentSpan.sampled = true;
-				}
-				if (req.headers["x-b3-spanid"]) {
-					options.parentSpan.id = req.headers["x-b3-spanid"].toLowerCase();
-				}
-			}
+	methods: {
+		authorize(ctx) {
+			this.logger.warn("AUTHORIZE");
+			return true;
 		}
 	}
 });
 
 broker.createService({
-	name: "test",
+	name: "greeter",
 	actions: {
-		check(ctx) {
-			this.logger.info("Meta", ctx.meta);
-			return { result: "OK" };
+		hello(ctx) {
+			return { result: "Hello" };
 		}
 	}
 });


### PR DESCRIPTION
Many developers issued that version 0.10 doesn't support multiple routes with the same path. This version fixes it but you should give a unique name for the routes if they have same path.

**Example**
You can call `/api/hi` without auth, but `/api/hello` only with auth.

```js
const ApiGateway = require("moleculer-web");

module.exports = {
    mixins: [ApiGateway],
    settings: {
        path: "/api",

        routes: [
            {
                name: "no-auth-route", // unique name
                path: "/",
                aliases: {
                    hi: "greeter.hello",
                }
            },
            {
                name: "with-auth-route", // unique name
                path: "/",
                aliases: {
                    "hello": "greeter.hello",
                },
                authorization: true
            }
        ]
    }
};
```