### PR TITLE
Multi authentication & authorization for routes

### DIFF
--- a/examples/multi-auth/index.js
+++ b/examples/multi-auth/index.js
@@ -1,0 +1,81 @@
+"use strict";
+
+/**
+ * This example shows how to define different authn/authz methods for different routes.
+ *
+ * Example:
+ *
+ *  - Try to call /aaa/hello. It will call "aaaAuthn" and "aaaAuthz" methods
+ * 		http://localhost:3000/aaa/hello
+ *
+ *  - Try to call /bbb/hello. It will call "bbbAuthn" and "bbbAuthz" methods
+ * 		http://localhost:3000/bbb/hello
+ *
+ *  - Try to call /ccc/hello. It will call "authenticate" and "authorize" original methods
+ * 		http://localhost:3000/bbb/hello
+ *
+ */
+
+let path 				= require("path");
+let { ServiceBroker } 	= require("moleculer");
+let ApiGatewayService 	= require("../../index");
+
+const { UnAuthorizedError, ERR_NO_TOKEN, ERR_INVALID_TOKEN } = require("../../src/errors");
+
+// Create broker
+let broker = new ServiceBroker({
+	logger: console
+});
+
+// Load other services
+broker.loadService(path.join(__dirname, "..", "test.service"));
+
+// Load API Gateway
+broker.createService({
+	mixins: ApiGatewayService,
+
+	settings: {
+
+		routes: [
+			{
+				path: "/aaa",
+				authentication: "aaaAuthn",
+				authorization: "aaaAuthz",
+				aliases: {
+					"GET hello": "test.hello"
+				}
+			},
+			{
+				path: "/bbb",
+				authentication: "bbbAuthn",
+				authorization: "bbbAuthz",
+				aliases: {
+					"GET hello": "test.hello"
+				}
+			},
+			{
+				path: "/ccc",
+				authentication: true,
+				authorization: true,
+				aliases: {
+					"GET hello": "test.hello"
+				}
+			}
+		]
+	},
+
+	methods: {
+		aaaAuthz() {
+			this.logger.info("Called 'aaaAuthz' method.");
+		},
+		bbbAuthz() {
+			this.logger.info("Called 'bbbAuthz' method.");
+		},
+		authorize() {
+			this.logger.info("Called original 'authorize' method.");
+		}
+	}
+});
+
+// Start server
+broker.start();

--- a/examples/multi-auth/index.js
+++ b/examples/multi-auth/index.js
@@ -65,11 +65,22 @@ broker.createService({
 	},
 
 	methods: {
+		aaaAuthn() {
+			this.logger.info("Called 'aaaAuthn' method.");
+		},
 		aaaAuthz() {
 			this.logger.info("Called 'aaaAuthz' method.");
 		},
+
+		bbbAuthn() {
+			this.logger.info("Called 'bbbAuthn' method.");
+		},
 		bbbAuthz() {
 			this.logger.info("Called 'bbbAuthz' method.");
+		},
+
+		authenticate() {
+			this.logger.info("Called original 'authenticate' method.");
 		},
 		authorize() {
 			this.logger.info("Called original 'authorize' method.");

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -2227,12 +2227,12 @@ describe("Test CORS", () => {
 			})
 			.then(() => broker.stop()).catch(err => broker.stop().then(() => { throw err; }));
 	});
-	
+
 	it("with custom global settings (function)", () => {
 		[broker, service, server] = setup({
 			cors: {
 				origin: (origin) => {
-					return origin === "http://localhost:3000";	
+					return origin === "http://localhost:3000";
 				},
 				exposedHeaders: "X-Response-Time",
 				credentials: true
@@ -2953,7 +2953,7 @@ describe("Test authentication", () => {
 			}]
 		})[1];
 
-		expect(service.routes[0].authentication).toBe(false);
+		expect(service.routes[0].authentication).toBeNull();
 	});
 
 	it("authenticated user", () => {
@@ -2978,7 +2978,7 @@ describe("Test authentication", () => {
 		});
 		const server = service.server;
 
-		expect(service.routes[0].authentication).toBe(true);
+		expect(typeof service.routes[0].authentication).toBe("function");
 
 		return broker.start()
 			.then(() => request(server)
@@ -3010,7 +3010,7 @@ describe("Test authentication", () => {
 		});
 		const server = service.server;
 
-		expect(service.routes[0].authentication).toBe(true);
+		expect(typeof service.routes[0].authentication).toBe("function");
 
 		return broker.start()
 			.then(() => request(server)
@@ -3042,7 +3042,7 @@ describe("Test authentication", () => {
 		});
 		const server = service.server;
 
-		expect(service.routes[0].authentication).toBe(true);
+		expect(typeof service.routes[0].authentication).toBe("function");
 
 		return broker.start()
 			.then(() => request(server)
@@ -3072,7 +3072,7 @@ describe("Test authorization", () => {
 			}]
 		})[1];
 
-		expect(service.routes[0].authorization).toBe(false);
+		expect(service.routes[0].authorization).toBeNull();
 	});
 
 	it("should return with data", () => {
@@ -3092,7 +3092,7 @@ describe("Test authorization", () => {
 		});
 		const server = service.server;
 
-		expect(service.routes[0].authorization).toBe(true);
+		expect(typeof service.routes[0].authorization).toBe("function");
 
 		return broker.start()
 			.then(() => request(server)
@@ -3124,7 +3124,7 @@ describe("Test authorization", () => {
 		});
 		const server = service.server;
 
-		expect(service.routes[0].authorization).toBe(true);
+		expect(typeof service.routes[0].authorization).toBe("function");
 
 		return broker.start()
 			.then(() => request(server)


### PR DESCRIPTION
This PR adds feature to define custom authentication and authorization methods for every routes. In this case you should set the method name instead of `true` value.

**Example**
```js
module.exports = {
    mixins: ApiGatewayService,

    settings: {

        routes: [
            {
                path: "/aaa",
                authentication: "aaaAuthn",
                authorization: "aaaAuthz",
                aliases: {
                    "GET hello": "test.hello"
                }
            },
            {
                path: "/bbb",
                authentication: "bbbAuthn",
                authorization: "bbbAuthz",
                aliases: {
                    "GET hello": "test.hello"
                }
            },
            {
                path: "/ccc",
                authentication: true,
                authorization: true,
                aliases: {
                    "GET hello": "test.hello"
                }
            }
        ]
    },

    methods: {
        aaaAuthn() {
            this.logger.info("Called 'aaaAuthn' method.");
        },
        aaaAuthz() {
            this.logger.info("Called 'aaaAuthz' method.");
        },

        bbbAuthn() {
            this.logger.info("Called 'bbbAuthn' method.");
        },
        bbbAuthz() {
            this.logger.info("Called 'bbbAuthz' method.");
        },

        authenticate() {
            this.logger.info("Called original 'authenticate' method.");
        },
        authorize() {
            this.logger.info("Called original 'authorize' method.");
        }
    }
}
```