### PR TITLE
skip services without settings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1455,6 +1455,7 @@ module.exports = {
 
 			const services = this.broker.registry.getServiceList({ withActions: true, grouping: true });
 			services.forEach(service => {
+				if(!service.settings) return;
 				const serviceName = service.fullName || getServiceFullname(service);
 
 				let basePaths = [];


### PR DESCRIPTION
Hi,
When autoAliases is set to true, a moleculer fails to start if it is clustered with moleculer java, this is caused by java services not expossing settings.rest since they may not be aware of moleculer web(js). thanks.