### PR TITLE
Fix to comment in multi-auth example

### DIFF
--- a/examples/multi-auth/index.js
+++ b/examples/multi-auth/index.js
@@ -12,7 +12,7 @@
  * 		http://localhost:3000/bbb/hello
  *
  *  - Try to call /ccc/hello. It will call "authenticate" and "authorize" original methods
- * 		http://localhost:3000/bbb/hello
+ * 		http://localhost:3000/ccc/hello
  *
  */
 


### PR DESCRIPTION
In context, this line would need to reference /ccc rather than /bbb

This might have been a copy/paste/forget error