### PR TITLE
Add alias as last parameter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -537,12 +537,12 @@ module.exports = {
 
 			// onBeforeCall handling
 			if (route.onBeforeCall) {
-				await route.onBeforeCall.call(this, ctx, route, req, res);
+				await route.onBeforeCall.call(this, ctx, route, req, res, alias);
 			}
 
 			// Authentication
 			if (route.authentication) {
-				const user = await route.authentication.call(this, ctx, route, req, res);
+				const user = await route.authentication.call(this, ctx, route, req, res, alias);
 				if (user) {
 					this.logger.debug("Authenticated user", user);
 					ctx.meta.user = user;
@@ -554,7 +554,7 @@ module.exports = {
 
 			// Authorization
 			if (route.authorization) {
-				await route.authorization.call(this, ctx, route, req, res);
+				await route.authorization.call(this, ctx, route, req, res, alias);
 			}
 
 			// Call the action or alias

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -2679,7 +2679,7 @@ describe("Test onBeforeCall & onAfterCall", () => {
 				expect(res.statusCode).toBe(200);
 				expect(res.text).toBe("Hello Custom");
 				expect(beforeCall).toHaveBeenCalledTimes(1);
-				expect(beforeCall).toHaveBeenCalledWith(expect.any(Context), expect.any(Object), expect.any(http.IncomingMessage), expect.any(http.ServerResponse));
+				expect(beforeCall).toHaveBeenCalledWith(expect.any(Context), expect.any(Object), expect.any(http.IncomingMessage), expect.any(http.ServerResponse), expect.any(Object));
 
 				const ctx = beforeCall.mock.calls[0][0];
 				const req = beforeCall.mock.calls[0][2];

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -2645,7 +2645,7 @@ describe("Test onBeforeCall & onAfterCall", () => {
 				expect(res.headers["x-custom-header"]).toBe("working");
 				expect(res.body).toBe("Hello Moleculer");
 				expect(beforeCall).toHaveBeenCalledTimes(1);
-				expect(beforeCall).toHaveBeenCalledWith(expect.any(Context), expect.any(Object), expect.any(http.IncomingMessage), expect.any(http.ServerResponse));
+				expect(beforeCall).toHaveBeenCalledWith(expect.any(Context), expect.any(Object), expect.any(http.IncomingMessage), expect.any(http.ServerResponse), expect.any(Object));
 
 				const ctx = beforeCall.mock.calls[0][0];
 				const req = beforeCall.mock.calls[0][2];
@@ -2989,7 +2989,7 @@ describe("Test authentication", () => {
 
 				expect(res.body).toBe(`Hello ${user.username}`);
 				expect(authenticate).toHaveBeenCalledTimes(1);
-				expect(authenticate).toHaveBeenCalledWith(expect.any(Context), expect.any(Object), expect.any(http.IncomingMessage), expect.any(http.ServerResponse));
+				expect(authenticate).toHaveBeenCalledWith(expect.any(Context), expect.any(Object), expect.any(http.IncomingMessage), expect.any(http.ServerResponse), expect.any(Object));
 			}).then(() => broker.stop()).catch(err => broker.stop().then(() => { throw err; }));
 	});
 
@@ -3021,7 +3021,7 @@ describe("Test authentication", () => {
 
 				expect(res.body).toBe("Who are you?");
 				expect(authenticate).toHaveBeenCalledTimes(1);
-				expect(authenticate).toHaveBeenCalledWith(expect.any(Context), expect.any(Object), expect.any(http.IncomingMessage), expect.any(http.ServerResponse));
+				expect(authenticate).toHaveBeenCalledWith(expect.any(Context), expect.any(Object), expect.any(http.IncomingMessage), expect.any(http.ServerResponse), expect.any(Object));
 			}).then(() => broker.stop()).catch(err => broker.stop().then(() => { throw err; }));
 	});
 
@@ -3057,7 +3057,7 @@ describe("Test authentication", () => {
 					name: "MoleculerError"
 				});
 				expect(authenticate).toHaveBeenCalledTimes(1);
-				expect(authenticate).toHaveBeenCalledWith(expect.any(Context), expect.any(Object), expect.any(http.IncomingMessage), expect.any(http.ServerResponse));
+				expect(authenticate).toHaveBeenCalledWith(expect.any(Context), expect.any(Object), expect.any(http.IncomingMessage), expect.any(http.ServerResponse), expect.any(Object));
 			}).then(() => broker.stop()).catch(err => broker.stop().then(() => { throw err; }));
 	});
 
@@ -3103,7 +3103,7 @@ describe("Test authorization", () => {
 
 				expect(res.body).toBe("Hello Moleculer");
 				expect(authorize).toHaveBeenCalledTimes(1);
-				expect(authorize).toHaveBeenCalledWith(expect.any(Context), expect.any(Object), expect.any(http.IncomingMessage), expect.any(http.ServerResponse));
+				expect(authorize).toHaveBeenCalledWith(expect.any(Context), expect.any(Object), expect.any(http.IncomingMessage), expect.any(http.ServerResponse), expect.any(Object));
 			}).then(() => broker.stop()).catch(err => broker.stop().then(() => { throw err; }));
 	});
 
@@ -3139,7 +3139,7 @@ describe("Test authorization", () => {
 					"name": "UnAuthorizedError"
 				});
 				expect(authorize).toHaveBeenCalledTimes(1);
-				expect(authorize).toHaveBeenCalledWith(expect.any(Context), expect.any(Object), expect.any(http.IncomingMessage), expect.any(http.ServerResponse));
+				expect(authorize).toHaveBeenCalledWith(expect.any(Context), expect.any(Object), expect.any(http.IncomingMessage), expect.any(http.ServerResponse), expect.any(Object));
 			}).then(() => broker.stop()).catch(err => broker.stop().then(() => { throw err; }));
 	});
 


### PR DESCRIPTION
Add `alias` to the following hooks as last parameter:
- `onBeforeCall`
- `authentication`
- `authorization`

You can access it in the hook handlers, e.g.:

```js
{
    path: "/",

    onBeforeCall(ctx, route, req, res, alias) {
        ctx.meta.aliasPath = alias.path;
    }
}
```