### PR TITLE
Broadcast event after alias regeneration

### DIFF
--- a/examples/test.service.js
+++ b/examples/test.service.js
@@ -11,6 +11,12 @@ module.exports = {
 		rest: ""
 	},
 
+	events: {
+		"$api.aliases.regenerated"() {
+			this.logger.info("Aliases regenerated!");
+		}
+	},
+
 	actions: {
 		hello: {
 			rest: "GET /hello",

--- a/src/index.js
+++ b/src/index.js
@@ -1670,6 +1670,8 @@ module.exports = {
 		this.regenerateAllAutoAliases = _.debounce(() => {
 			/* istanbul ignore next */
 			this.routes.forEach(route => route.opts.autoAliases && this.regenerateAutoAliases(route));
+
+			this.broker.broadcast("$api.aliases.regenerated");
 		}, debounceTime);
 	},
 


### PR DESCRIPTION
Fix #288 

Sending `$api.aliases.regenerated` event after regeneration executed.