### PR TITLE
fix: add 201 Created to status codes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -700,7 +700,7 @@ module.exports = {
 			}
 
 			// Redirect
-			if (res.statusCode >= 300 && res.statusCode < 400 && res.statusCode !== 304) {
+			if (res.statusCode==201 || (res.statusCode >= 300 && res.statusCode < 400 && res.statusCode !== 304)) {
 				const location = ctx.meta.$location;
 				/* istanbul ignore next */
 				if (!location) {

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -311,6 +311,7 @@ describe("Test responses", () => {
 			.get("/test/customStatus")
 			.then(res => {
 				expect(res.statusCode).toBe(201);
+				expect(res.headers["location"]).toBe("/new/entity");
 				expect(res.res.statusMessage).toEqual("Entity created");
 				expect(res.text).toEqual("");
 			});

--- a/test/services/test.service.js
+++ b/test/services/test.service.js
@@ -219,6 +219,7 @@ module.exports = {
 		customStatus: {
 			handler(ctx) {
 				ctx.meta.$statusCode = 201;
+				ctx.meta.$location = "/new/entity";
 				ctx.meta.$statusMessage = "Entity created";
 			}
 		},


### PR DESCRIPTION
The `Location` header is _also_ used by the `201 Created` status code.  But the currently logic filters out the information provided in `ctx.meta.$location` if I return `ctx.meta.$statusCode = 201`.  This should not happen.  The `Location` header is essential in a `201 Created` response.  I've changed to logic so that `201` is included in the status codes that passthrough `ctx.meta.$location` to the `Location` header.