### PR TITLE
fix: #298: register on close and error event on response

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -416,6 +416,8 @@ module.exports = {
 
 			return new this.Promise(async (resolve, reject) => {
 				res.once("finish", () => resolve(true));
+				res.once("close", (err) => reject(err));
+				res.once("error", (err) => reject(err));
 
 				try {
 					await composeThen.call(this, req, res, ...route.middlewares);


### PR DESCRIPTION
Resolves #298.
Added handlers to handle `error` and `close` events on response and resolve/reject respectively the context caller.