### PR TITLE
fix: resolve promise when close event is fired for res

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -416,7 +416,7 @@ module.exports = {
 
 			return new this.Promise(async (resolve, reject) => {
 				res.once("finish", () => resolve(true));
-				res.once("close", (err) => reject(err));
+				res.once("close", () => resolve(true));
 				res.once("error", (err) => reject(err));
 
 				try {


### PR DESCRIPTION
Hello,
this PR to change the "close" event handler from reject to resolve in order to make the promise end with no errors.
When a http requested is issued and then cancelled by the client the "finish" event is not triggered (https://nodejs.org/docs/latest-v16.x/api/http.html#event-close_1)

Thanks!