### PR TITLE
add `originalUrl`, `parsedUrl`, and `query` to request typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -681,6 +681,7 @@ declare module "moleculer-web" {
 		$ctx: Context;
 		$route: Route;
 		$service: Service;
+		locals: Record<string, unknown>;
 	}
 
 	const ApiGatewayService: ServiceSchema & { Errors: ApiGatewayErrors, IncomingRequest: IncomingRequest, GatewayResponse: GatewayResponse };

--- a/index.d.ts
+++ b/index.d.ts
@@ -657,7 +657,7 @@ declare module "moleculer-web" {
 		$params: any;
 		$route: Route;
 		$service: Service;
-		$startTime: Array<number>;
+		$startTime: [number, number];
 		/**
 		 * Value from `IncomingMessage#url`. Includes query parameters.
 		 * `/path?id=1&example=true`

--- a/index.d.ts
+++ b/index.d.ts
@@ -651,13 +651,30 @@ declare module "moleculer-web" {
 	class IncomingRequest extends IncomingMessage {
 		$action: ActionSchema;
 		$alias: Alias;
-		$ctx: Context;
+		$ctx: Context<{ req: IncomingMessage; res: ServerResponse; }>;
 		$endpoint: ActionEndpoint;
 		$next: any;
 		$params: any;
 		$route: Route;
 		$service: Service;
 		$startTime: Array<number>;
+		/**
+		 * Value from `IncomingMessage#url`. Includes query parameters.
+		 * `/path?id=1&example=true`
+		 */
+		originalUrl: string;
+		/**
+		 * Value from `IncomingMessage#url`. Query parameters stripped off.
+		 * `/path`
+		 */
+		parsedUrl: string;
+		/**
+		 * Parsed query parameters as an object.
+		 * ```javascript
+		 * { id: '1', example: 'true' }
+		 * ```
+		 */ 
+		query: Record<string, string>;
 	}
 
 	class GatewayResponse extends ServerResponse {


### PR DESCRIPTION
Add some properties set on `IncomingRequest` by `moleculer-web`. 

I had looked at adding `locals` to `GatewayResponse` as well though held off as it seemed primarily internal. Would it be worth adding?