### PR TITLE
add default reqTimeout

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -88,6 +88,9 @@ module.exports = {
 		// HTTP Server Timeout
 		httpServerTimeout: null,
 
+		// Request Timeout. More info: https://github.com/moleculerjs/moleculer-web/issues/206
+		requestTimeout: 300000, // Sets node.js v18 default timeout: https://nodejs.org/api/http.html#serverrequesttimeout
+
 		// Optimize route order
 		optimizeOrder: true,
 	},
@@ -303,6 +306,9 @@ module.exports = {
 				this.logger.debug("Override default http(s) server timeout:", this.settings.httpServerTimeout);
 				this.server.setTimeout(this.settings.httpServerTimeout);
 			}
+	
+			this.server.requestTimeout = this.settings.requestTimeout
+			this.logger.debug("Setting http(s) server request timeout to:", this.settings.requestTimeout);
 		},
 
 		/**


### PR DESCRIPTION
Fixes https://github.com/moleculerjs/moleculer-web/issues/206

In node.js versions < v18 this was set to 0 (meaning disabled).

However, in the docs it is stated that:
> It must be set to a non-zero value (e.g. 120 seconds) to protect against potential Denial-of-Service attacks in case the server is deployed without a reverse proxy in front.

In node.js v18 the default value is `300000` ms = 5 minutes,

This PR uses node.js v18 default value