### PR TITLE
fix rate limit validation in alias handler

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -520,13 +520,13 @@ module.exports = {
 			}
 
 			// Rate limiter
-			if (route.rateLimit) {
-				const opts = route.rateLimit;
-				const store = route.rateLimit.store;
+			if (route.opts.rateLimit) {
+				const opts = route.opts.rateLimit;
+				const store = route.opts.rateLimit.store;
 
 				const key = opts.key(req);
 				if (key) {
-					const remaining = opts.limit - await store.inc(key);
+					const remaining = opts.limit - store.inc(key);
 					if (opts.headers) {
 						res.setHeader("X-Rate-Limit-Limit", opts.limit);
 						res.setHeader("X-Rate-Limit-Remaining", Math.max(0, remaining));


### PR DESCRIPTION
In addition to the fix , we have to pass the instance of store .
Example: 
`module.exports = {
  name: "api",
  mixins: [ApiGateway],

  settings: {
    port: process.env.GATEWAY_PORT || 3000,

    routes: [
      {
        path: "/test-service",
        rateLimit: {
          window: 10 * 1000,
          limit: 2,
          headers: true,
          key: (req) => req.headers["x-forwarded-for"],
          store: new MemoryStore(), // HERE USE INSTANCE
        },
        whitelist: [
          "test-service.test",
        ],
        bodyParsers: {
          json: { limit: "2MB" },
        },
        aliases: {
          "POST /test": "test-service.testAction",
        },
        
      },
    ],

    onError(req, res, err) {
      console.error(err);
      res.setHeader("Content-Type", "text/plain");
      res.writeHead(err.code);
      res.end(err.data || err.message);
    },
  },
  methods: {},
};`