### PR TITLE
update qs package to mitigate CVE-2022-24999

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "kleur": "^4.1.4",
         "lodash": "^4.17.21",
         "path-to-regexp": "^3.1.0",
-        "qs": "^6.10.1",
+        "qs": "^6.11.0",
         "serve-static": "^1.14.1"
       },
       "devDependencies": {
@@ -6176,7 +6176,8 @@
     },
     "node_modules/qs": {
       "version": "6.11.0",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
       "dependencies": {
         "side-channel": "^1.0.4"
       },
@@ -12193,6 +12194,8 @@
     },
     "qs": {
       "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
       "requires": {
         "side-channel": "^1.0.4"
       }

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "kleur": "^4.1.4",
     "lodash": "^4.17.21",
     "path-to-regexp": "^3.1.0",
-    "qs": "^6.10.1",
+    "qs": "^6.11.0",
     "serve-static": "^1.14.1"
   },
   "engines": {


### PR DESCRIPTION
Changes:

- chore(depdencies): update qs package to mitigate CVE-2022-24999

Notes:
https://github.com/advisories/GHSA-hrpp-h998-j3pp