### PR TITLE
fix: correct types for route middleware functions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -403,11 +403,11 @@ declare module "moleculer-web" {
 		(deferToNext: "route"): void;
 	}
 
-	type routeMiddleware = (req: IncomingMessage, res: ServerResponse, next: NextFunction) => void;
+	type routeMiddleware = (req: IncomingRequest, res: GatewayResponse, next: NextFunction) => void;
 	type routeMiddlewareError = (
 		err: any,
-		req: IncomingMessage,
-		res: ServerResponse,
+		req: IncomingRequest,
+		res: GatewayResponse,
 		next: NextFunction,
 	) => void;
 


### PR DESCRIPTION
When logging `req` and `res` from middleware functions the output does not match `IncomingMessage` and `ServerResponse` from `node`. Instead they seem to match moleculers extensions of these types: `ÌncomingMessage` and `GatewayResponse`.