### PR TITLE
fix: #331 mergeParams always true for internal services

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -452,6 +452,11 @@ module.exports = {
 					urlPath = urlPath.replace(this._isscRe, "$");
 					let action = urlPath;
 
+					// #331 Always merge parameters for internal services
+					if (urlPath.indexOf("$") !== -1) {
+						route.opts.mergeParams = true;
+					}
+
 					// Resolve aliases
 					if (foundAlias) {
 						const alias = foundAlias.alias;


### PR DESCRIPTION
I discovered that `mergeParams: false` was the causing the issue #331.

Developers should continue to use this configuration without experiencing side effects in internal services.

I implemented a minor workaround in `src/index.js:L455` to force parameter merging for internal services, and it resolved the issue.

![image](https://github.com/moleculerjs/moleculer-web/assets/2074685/7cc14fa6-567e-491a-b3f8-f6e37e45bfea)