### PR TITLE
feat(compileRest): allow to reuse the rest settings, to generate rest path from parameters

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -279,8 +279,31 @@ module.exports = {
 				return this.removeRoute(ctx.params.path);
 			}
 		},
-	},
+		compileRest: {
+			params: {
+				action: {
+					type: "string"
+				},
+				params: {
+					type: "record",
+					optional: true,
+					key: { type: "string", pattern: /[A-Za-z0-9_]+/ },
+					value: { type: "string", convert: true, optional: true }
+				}
+			},
+			visibility: "public",
+			handler(ctx) {
+				const actionName = ctx.params.action;
+				const foundAlias = this.aliases.find(alias => alias.action === actionName);
 
+				if(!foundAlias) {
+					return;
+				}
+
+				return foundAlias.compile(ctx.params.params);
+			}
+		}
+	},
 	methods: {
 		/**
 		 * Create HTTP server


### PR DESCRIPTION
This PR allow to call a endpoint to generate the rest url . 

allow to do : 
```typescript
const svc = {
 name: "users",
 settings: {
  rest: '/users'
 },
 actions: {
  action: {
    rest: 'GET /:id'
  }
 }
}

await ctx.call('gateway.getRest', {action: 'my.action', params: {id:123}}); // => return /users/123
```

It can be usefull if you want to setup hypermedias, or just generate a link

---

I'm not sure about the naming, so I reuse the naming from `path-to-regexp` "compile" . 

Not sure about the error throw if missing parameters, but it seems that path-regexp throw an error if a parameter is missing (I also tried with parameter `validate` to false) . 

---

State of the PR : 
 [ ] - do tests
 [ ] - write documentation