### PR TITLE
imp(index.d.ts): correct export ts types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -474,7 +474,7 @@ declare module "moleculer-web" {
 		 */
 		use?: (routeMiddleware | routeMiddlewareError)[];
 	};
-	export type ApiRouteSchema = CommonSettingSchema & {
+	export interface ApiRouteSchema extends CommonSettingSchema {
 		/**
 		 * You can use alias names instead of action names. You can also specify the method. Otherwise it will handle every method types.<br>
 		 * Using named parameters in aliases is possible. Named parameters are defined by prefixing a colon to the parameter name (:name).
@@ -591,9 +591,9 @@ declare module "moleculer-web" {
 		 * @see https://moleculer.services/docs/0.14/moleculer-web.html#Whitelist
 		 */
 		whitelist?: (string | RegExp)[];
-	};
+	}
 
-	export type ApiSettingsSchema = CommonSettingSchema & {
+	export interface ApiSettingsSchema extends CommonSettingSchema {
 		/**
 		 * It serves assets with the [serve-static](https://github.com/expressjs/serve-static) module like ExpressJS.
 		 * @see https://moleculer.services/docs/0.14/moleculer-web.html#Serve-static-files
@@ -707,7 +707,7 @@ declare module "moleculer-web" {
 		 * for extra setting's keys
 		 */
 		[k: string]: any;
-	};
+	}
 
 	export class IncomingRequest extends IncomingMessage {
 		$action: ActionSchema;
@@ -733,8 +733,6 @@ declare module "moleculer-web" {
 
 	const ApiGatewayService: ServiceSchema & {
 		Errors: ApiGatewayErrors;
-		IncomingRequest: IncomingRequest;
-		GatewayResponse: GatewayResponse;
 		RateLimitStores: RateLimitStores;
 	};
 	export default ApiGatewayService;


### PR DESCRIPTION
- change `export type` to `export interface` due to `error TS4082`
![image](https://github.com/moleculerjs/moleculer-web/assets/32500015/4291162f-a1f9-44fe-9f5d-76f775803431)
- remove non-exported `IncomingRequest`, `GatewayResponse` from `export default`