### PR TITLE
fix: request url not logged correctly

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -983,7 +983,7 @@ module.exports = {
 			if (req.$route && !req.$route.logging) return;
 
 			if (this.settings.logRequest && this.settings.logRequest in this.logger)
-				this.logger[this.settings.logRequest](`=> ${req.method} ${req.url}`);
+				this.logger[this.settings.logRequest](`=> ${req.method} ${req.originalUrl}`);
 		},
 
 		/**


### PR DESCRIPTION
We have problem with our request logs. Wasn't able to reproduce it in a test but for some reason the request log gets cropped (we don't get the full url). The response log is always correct and I noticed that the `req.originalUrl` is used for the response. Using the same url in both response and request seemed reasonable. 