### PR TITLE
Update index.d.ts - export RateLimitStores/ApiGatewayErrors

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -61,7 +61,7 @@ declare module "moleculer-web" {
 		inc(key: string): number | Promise<number>;
 	}
 
-	interface RateLimitStores {
+	export interface RateLimitStores {
 		MemoryStore: typeof MemoryStore;
 	}
 
@@ -335,7 +335,7 @@ declare module "moleculer-web" {
 		constructor(type: string, data: any);
 	}
 
-	interface ApiGatewayErrors {
+	export interface ApiGatewayErrors {
 		InvalidRequestBodyError: typeof InvalidRequestBodyError;
 		InvalidResponseTypeError: typeof InvalidResponseTypeError;
 		UnAuthorizedError: typeof UnAuthorizedError;


### PR DESCRIPTION
`satisfies` issue:

```typescript
export default {
  name: 'gateway',
  mixins: [ApiGateway],
  .......
} satisfies IServiceSchema<ServiceSettingSchema>;
```

=>

```typescript
TS4082: Default export of the module has or is using private name ApiGatewayErrors
TS4082: Default export of the module has or is using private name RateLimitStores
```