### PR TITLE
feat: added blacklist functionality for auto aliases

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -11,12 +11,12 @@ jobs:
         node-version: [10.x, 12.x, 14.x, 16.x, 18.x, 20.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: node_modules
         key: ${{ matrix.node-version }}-node-${{ hashFiles('**/package-lock.json') }}

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The `moleculer-web` is the official API gateway service for [Moleculer](https://
 * support file uploading
 * alias names (with named parameters & REST shorthand)
 * whitelist
+* blacklist
 * multiple body parsers (json, urlencoded)
 * CORS headers
 * ETags

--- a/index.d.ts
+++ b/index.d.ts
@@ -367,6 +367,7 @@ declare module "moleculer-web" {
 		cors: CorsOptions;
 		etag: boolean | "weak" | "strong" | Function;
 		hasWhitelist: boolean;
+		hasBlacklist: boolean;
 		logging: boolean;
 		mappingPolicy: string;
 		middlewares: Function[];
@@ -375,6 +376,7 @@ declare module "moleculer-web" {
 		opts: any;
 		path: string;
 		whitelist: string[];
+		blacklist: string[];
 	}
 
 	type onBeforeCall = (
@@ -514,6 +516,7 @@ declare module "moleculer-web" {
 		 * The gateway will dynamically build the full routes from service schema.
 		 * Gateway will regenerate the routes every time a service joins or leaves the network.<br>
 		 * Use `whitelist` parameter to specify services that the Gateway should track and build the routes.
+		 * And `blacklist` parameter to specify services that the Gateway should not track and build the routes.
 		 * @see https://moleculer.services/docs/0.14/moleculer-web.html#Auto-alias
 		 */
 		autoAliases?: boolean;
@@ -597,6 +600,15 @@ declare module "moleculer-web" {
 		 * @see https://moleculer.services/docs/0.14/moleculer-web.html#Whitelist
 		 */
 		whitelist?: (string | RegExp)[];
+		/**
+		 * If you don’t want to publish all actions, you can filter them with blacklist option.<br>
+		 * Use match strings or regexp in list. To enable all actions, use "**" item.<br>
+		 * "posts.*": `Access any actions in 'posts' service`<br>
+		 * "users.list": `Access call only the 'users.list' action`<br>
+		 * /^math\.\w+$/: `Access any actions in 'math' service`<br>
+		 * @see https://moleculer.services/docs/0.14/moleculer-web.html#Blacklist
+		 */
+		blacklist?: (string | RegExp)[];
 	}
 
 	type APISettingServer =

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ const _ = require("lodash");
 const bodyParser = require("body-parser");
 const serveStatic = require("serve-static");
 const isReadableStream = require("isstream").isReadable;
-const { pipeline } = require('stream');
+const { pipeline } = require("stream");
 
 const { MoleculerError, MoleculerServerError, ServiceNotFoundError } = require("moleculer").Errors;
 const { ServiceUnavailableError, NotFoundError, ForbiddenError, RateLimitExceeded, ERR_ORIGIN_NOT_ALLOWED } = require("./errors");
@@ -521,6 +521,14 @@ module.exports = {
 				}
 			}
 
+			// Blacklist check
+			if (alias.action && route.hasBlacklist) {
+				if (this.checkBlacklist(route, alias.action)) {
+					this.logger.debug(`  The '${alias.action}' action is in the blacklist!`);
+					throw new ServiceNotFoundError({ action: alias.action });
+				}
+			}
+
 			// Rate limiter
 			if (route.rateLimit) {
 				const opts = route.rateLimit;
@@ -822,9 +830,9 @@ module.exports = {
 				if (isReadableStream(data)) { //Stream response
 					pipeline(data, res, err => {
 						if (err) {
-							this.logger.warn("Stream got an error.", { err, url: req.url, actionName: action.name })
+							this.logger.warn("Stream got an error.", { err, url: req.url, actionName: action.name });
 						}
-					})
+					});
 				} else {
 					res.end(chunk);
 				}
@@ -1546,12 +1554,12 @@ module.exports = {
 
 							// Blacklist check
 							if (route.hasBlacklist) {
-								if (this.checkBlacklist(route, alias.action)) {
+								if (this.checkBlacklist(route, action.name)) {
 									this.logger.debug(
-										`  The '${alias.action}' action is in the blacklist!`
+										`  The '${action.name}' action is in the blacklist!`
 									);
 									throw new ServiceNotFoundError({
-										action: alias.action,
+										action: action.name,
 									});
 								}
 							}

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -777,6 +777,125 @@ describe("Test whitelist", () => {
 	});
 });
 
+describe("Test blacklist", () => {
+	let broker;
+	let service;
+	let server;
+	beforeAll(() => {
+		[broker, service, server] = setup({
+			routes: [
+				{
+					path: "/api",
+					blacklist: ["test.greeter", "math.sub", /^test\.json/],
+				},
+			],
+		});
+		broker.loadService("./test/services/math.service");
+		return broker.start();
+	});
+	afterAll(() => broker.stop());
+	it("GET /api/test/hello", () => {
+		return request(server)
+			.get("/api/test/hello")
+			.then((res) => {
+				expect(res.statusCode).toBe(200);
+				expect(res.headers["content-type"]).toBe(
+					"application/json; charset=utf-8"
+				);
+				expect(res.body).toBe("Hello Moleculer");
+			});
+	});
+	it("GET /api/test/json", () => {
+		return request(server)
+			.get("/api/test/json")
+			.then((res) => {
+				expect(res.statusCode).toBe(404);
+				expect(res.headers["content-type"]).toBe(
+					"application/json; charset=utf-8"
+				);
+				expect(res.body).toEqual({
+					code: 404,
+					message: "Service 'test.json' is not found.",
+					name: "ServiceNotFoundError",
+					type: "SERVICE_NOT_FOUND",
+					data: {
+						action: "test.json",
+					},
+				});
+			});
+	});
+	it("GET /api/test/jsonArray", () => {
+		return request(server)
+			.get("/api/test/jsonArray")
+			.then((res) => {
+				expect(res.statusCode).toBe(404);
+				expect(res.headers["content-type"]).toBe(
+					"application/json; charset=utf-8"
+				);
+				expect(res.body).toEqual({
+					code: 404,
+					message: "Service 'test.jsonArray' is not found.",
+					name: "ServiceNotFoundError",
+					type: "SERVICE_NOT_FOUND",
+					data: {
+						action: "test.jsonArray",
+					},
+				});
+			});
+	});
+	it("GET /api/test/greeter", () => {
+		return request(server)
+			.get("/api/test/greeter")
+			.then((res) => {
+				expect(res.statusCode).toBe(404);
+				expect(res.headers["content-type"]).toBe(
+					"application/json; charset=utf-8"
+				);
+				expect(res.body).toEqual({
+					code: 404,
+					message: "Service 'test.greeter' is not found.",
+					name: "ServiceNotFoundError",
+					type: "SERVICE_NOT_FOUND",
+					data: {
+						action: "test.greeter",
+					},
+				});
+			});
+	});
+	it("GET /api/math.add", () => {
+		return request(server)
+			.get("/api/math.add")
+			.query({ a: 5, b: 8 })
+			.then((res) => {
+				expect(res.statusCode).toBe(200);
+				expect(res.headers["content-type"]).toBe(
+					"application/json; charset=utf-8"
+				);
+				expect(res.body).toBe(13);
+			});
+	});
+	it("GET /api/math.sub", () => {
+		return request(server)
+			.get("/api/math.sub")
+			.query({ a: 5, b: 8 })
+			.then((res) => {
+				expect(res.statusCode).toBe(404);
+				expect(res.headers["content-type"]).toBe(
+					"application/json; charset=utf-8"
+				);
+				expect(res.body).toEqual({
+					code: 404,
+					message: "Service 'math.sub' is not found.",
+					name: "ServiceNotFoundError",
+					type: "SERVICE_NOT_FOUND",
+					data: {
+						action: "math.sub",
+					},
+				});
+			});
+	});
+});
+
 describe("Test aliases", () => {
 	let broker;
 	let service;


### PR DESCRIPTION
moleculer web already has a whitelist option for the auto alias functionality, but it lacks a blacklist functionality.

In which use case is this needed?
We have multiple services that act as gateways, each mapped to a different subdomain and each of them should only list relevant routes, doing this with whitelist becomes extremely cumbersome when you create more than a handful of services.