### PR TITLE
fix: update blacklist handling to return instead of throwing an error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -525,7 +525,7 @@ module.exports = {
 			if (alias.action && route.hasBlacklist) {
 				if (this.checkBlacklist(route, alias.action)) {
 					this.logger.debug(`  The '${alias.action}' action is in the blacklist!`);
-					throw new ServiceNotFoundError({ action: alias.action });
+					return;
 				}
 			}
 


### PR DESCRIPTION
I recently introduced the Blacklist feature (different username @jappyjan , same person :D but this time using my work account ^^)
Tuns out that i accidentally introduced a bug which causes the moleculer broker/service to kill the process instead of just not executing an action.

This PR fixes it by replacing the throwing of an error when a service is blacklisted with a simple return like we do it for the whitelist too.