### PR TITLE
fix: crash when the upload file size exceeds the limit

### DIFF
--- a/src/alias.js
+++ b/src/alias.js
@@ -160,6 +160,9 @@ class Alias {
 				}
 				file.destroy(new PayloadTooLarge({ fieldname, filename, encoding, mimetype }));
 			});
+			file.on("error", err => {
+				busboy.emit("error", err);
+			});
 			numOfFiles++;
 			promises.push(ctx.call(this.action, file, _.defaultsDeep({}, this.route.opts.callOptions, { meta: {
 				fieldname: fieldname,


### PR DESCRIPTION
Based on the internal code of node stream, when calling destroy function with an error, it will emit an error event then close event.

<img width="916" alt="Screenshot 2025-04-03 at 11 22 15" src="https://github.com/user-attachments/assets/e0f2ce20-7801-44de-a03d-d1a031186ac5" />
