### PR TITLE
fix(d.ts): Remove export assignment

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -722,5 +722,3 @@ const ApiGatewayService: ServiceSchema & {
 };
 
 export default ApiGatewayService;
-
-export = ApiGatewayService;


### PR DESCRIPTION
This `export =` assignement breaks TS by preventing anyone to import declared types as they were overwritten by `ApiGatewayService`.

TS also reported this error:
```
TS2309: An export assignment cannot be used in a module with other exported elements.
```

I'm not sure on why this was added in the first place so I may have missed something.